### PR TITLE
Rename HWC overdose to Opioid overdose reporting

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyakeypop/metadata/KpMetadata.java
+++ b/api/src/main/java/org/openmrs/module/kenyakeypop/metadata/KpMetadata.java
@@ -238,7 +238,7 @@ public class KpMetadata extends AbstractMetadataBundle {
 		install(form("Peer Overdose Reporting Tool", "Peer Overdose Reporting Tool",
 		    KpMetadata._EncounterType.KP_PEER_OVERDOSE_REPORTING, "1", KpMetadata._Form.KP_PEER_OVERDOSE_REPORTING_FORM));
 		
-		install(form("HCW Overdose Reporting Tool", "HCW Overdose Reporting Tool",
+		install(form("Opioid Overdose Reporting", "Opioid Overdose Reporting Tool",
 		    KpMetadata._EncounterType.KP_HCW_OVERDOSE_REPORTING, "1", KpMetadata._Form.KP_HCW_OVERDOSE_REPORTING_FORM));
 		
 		install(form("Contact form", null, KpMetadata._EncounterType.KP_CONTACT, "1", KpMetadata._Form.KP_CONTACT_FORM));

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -53,7 +53,7 @@
                 <ref bean="kenyakeypop.form.kpClientEnrollment" />
                 <ref bean="kenyakeypop.form.kpClientTracing"/>
                 <ref bean="kenyakeypop.form.kpSTITreatment"/>
-                <ref bean="kenyakeypop.form.kpPeerOverdoseReporting"/>
+                <!-- <ref bean="kenyakeypop.form.kpPeerOverdoseReporting"/> -->
                 <ref bean="kenyakeypop.form.kpHealthWorkerOverdoseReporting"/>
                 <ref bean="kenyakeypop.form.kpViolenceScreening"/>
                 <ref bean="kenyakeypop.form.kpReferral"/>


### PR DESCRIPTION
We have also removed peer overdose form from being shown.